### PR TITLE
Halt Inquirer if no repositories are found.

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,9 +69,13 @@ const startInquirer = () => {
     })
 }
 
-;+(async () => {
-  await getDirs(rootDirectory)
-  startInquirer()
-})()
+  ; +(async () => {
+    await getDirs(rootDirectory)
+    if (!remotes.length) {
+      console.log(`Unable to locate any repositories at "${rootDirectory}"`)
+      return
+    }
+    startInquirer()
+  })()
 
 module.exports = { startInquirer, pullDir, getDirs }


### PR DESCRIPTION
If the user runs the `anypull` command in a directory that does not have any git repositories, they will get stuck on an empty options screen.  To avoid this, simply check to see if remotes has a value before proceeding to launch Inquirer.